### PR TITLE
Bmckay959 ignore case str helper before after

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -83,8 +83,12 @@ class Str
      * @param  string  $search
      * @return string
      */
-    public static function after($subject, $search)
+    public static function after($subject, $search, $ignoreCase = false)
     {
+        if($ignoreCase) {
+            return $search === '' ? $subject : array_reverse(preg_split("/$search/i", $subject, 2))[0];
+        }
+
         return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
     }
 
@@ -142,13 +146,17 @@ class Str
      * @param  string  $search
      * @return string
      */
-    public static function before($subject, $search)
+    public static function before($subject, $search, $ignoreCase = false)
     {
         if ($search === '') {
             return $subject;
         }
 
-        $result = strstr($subject, (string) $search, true);
+        if($ignoreCase) {
+            $result = stristr($subject, (string) $search, true);
+        } else {
+            $result = strstr($subject, (string) $search, true);
+        }
 
         return $result === false ? $subject : $result;
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -216,6 +216,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('han', Str::before('han0nah', '0'));
         $this->assertSame('han', Str::before('han0nah', 0));
         $this->assertSame('han', Str::before('han2nah', 2));
+        // Ignore Case
+        $this->assertSame('han', Str::before('hannah', 'NAH', true));
+        $this->assertSame('ha', Str::before('hannah', 'N', true));
+        $this->assertSame('ééé ', Str::before('ééé hannah', 'HAN', true));
+        $this->assertSame('hannah', Str::before('hannah', 'XXXX', true));
+        $this->assertSame('hannah', Str::before('hannah', '', true));
+        $this->assertSame('han', Str::before('han0nah', '0', true));
+        $this->assertSame('han', Str::before('han0nah', 0, true));
+        $this->assertSame('han', Str::before('han2nah', 2, true));
     }
 
     public function testStrBeforeLast()
@@ -271,6 +280,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('nah', Str::after('han0nah', '0'));
         $this->assertSame('nah', Str::after('han0nah', 0));
         $this->assertSame('nah', Str::after('han2nah', 2));
+        // Ignore Case
+        $this->assertSame('nah', Str::after('hannah', 'HAN', true));
+        $this->assertSame('nah', Str::after('hannah', 'N', true));
+        $this->assertSame('nah', Str::after('ééé hannah', 'HAN', true));
+        $this->assertSame('hannah', Str::after('hannah', 'XXXX', true));
+        $this->assertSame('hannah', Str::after('hannah', '', true));
+        $this->assertSame('nah', Str::after('han0nah', '0', true));
+        $this->assertSame('nah', Str::after('han0nah', 0, true));
+        $this->assertSame('nah', Str::after('han2nah', 2, true));
     }
 
     public function testStrAfterLast()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -216,6 +216,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('han', Str::before('han0nah', '0'));
         $this->assertSame('han', Str::before('han0nah', 0));
         $this->assertSame('han', Str::before('han2nah', 2));
+        $this->assertSame('hannah', Str::before('hannah', 'NAH'));
         // Ignore Case
         $this->assertSame('han', Str::before('hannah', 'NAH', true));
         $this->assertSame('ha', Str::before('hannah', 'N', true));
@@ -225,6 +226,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('han', Str::before('han0nah', '0', true));
         $this->assertSame('han', Str::before('han0nah', 0, true));
         $this->assertSame('han', Str::before('han2nah', 2, true));
+        // Ignore Case Flipped
+        $this->assertSame('HAN', Str::before('HANNAH', 'nah', true));
+        $this->assertSame('HA', Str::before('HANNAH', 'n', true));
+        $this->assertSame('ééé ', Str::before('ééé HANNAH', 'han', true));
+        $this->assertSame('HANNAH', Str::before('HANNAH', 'xxxx', true));
+        $this->assertSame('HANNAH', Str::before('HANNAH', '', true));
+        $this->assertSame('HAN', Str::before('HAN0NAH', '0', true));
+        $this->assertSame('HAN', Str::before('HAN0NAH', 0, true));
+        $this->assertSame('HAN', Str::before('HAN2NAH', 2, true));
     }
 
     public function testStrBeforeLast()
@@ -280,6 +290,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('nah', Str::after('han0nah', '0'));
         $this->assertSame('nah', Str::after('han0nah', 0));
         $this->assertSame('nah', Str::after('han2nah', 2));
+        $this->assertSame('hannah', Str::after('hannah', 'HAN'));
         // Ignore Case
         $this->assertSame('nah', Str::after('hannah', 'HAN', true));
         $this->assertSame('nah', Str::after('hannah', 'N', true));
@@ -289,6 +300,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('nah', Str::after('han0nah', '0', true));
         $this->assertSame('nah', Str::after('han0nah', 0, true));
         $this->assertSame('nah', Str::after('han2nah', 2, true));
+        // Ignore Case Flipped
+        $this->assertSame('NAH', Str::after('HANNAH', 'han', true));
+        $this->assertSame('NAH', Str::after('HANNAH', 'n', true));
+        $this->assertSame('NAH', Str::after('ééé HANNAH', 'han', true));
+        $this->assertSame('HANNAH', Str::after('HANNAH', 'xxxx', true));
+        $this->assertSame('HANNAH', Str::after('HANNAH', '', true));
+        $this->assertSame('NAH', Str::after('HAN0NAH', '0', true));
+        $this->assertSame('NAH', Str::after('HAN0NAH', 0, true));
+        $this->assertSame('NAH', Str::after('HAN2NAH', 2, true));
     }
 
     public function testStrAfterLast()


### PR DESCRIPTION
Option to ignore case on string helper `before` and `after`
